### PR TITLE
Bottom bar attendees

### DIFF
--- a/components/Event/Bottom-Bar.js
+++ b/components/Event/Bottom-Bar.js
@@ -1,0 +1,27 @@
+function  BottonBar(props){
+  return (
+      <div class="fixed bottom-0 left-0 z-50 w-full h-20 bg-white flex flex-row justify-between">
+        <div className="flex flex-col self-center">
+          <span>WED, APR 26 - 6:00 PDT</span>
+          <span className="font-bold">{props.title}</span>
+        </div>
+        <div className="flex flex-row gap-2 self-center items-center">
+          <span>Free</span>
+          <span>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0111.186 0z" />
+            </svg>
+          </span>
+          <span className="p-3 border-[1px] border-blue rounded-lg">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 8.25H7.5a2.25 2.25 0 00-2.25 2.25v9a2.25 2.25 0 002.25 2.25h9a2.25 2.25 0 002.25-2.25v-9a2.25 2.25 0 00-2.25-2.25H15m0-3l-3-3m0 0l-3 3m3-3V15" />
+            </svg>
+          </span>
+          <span>
+            <button type="button" className="px-5 py-3 bg-red-500 rounded-lg font-bold text-white" onClick={() => props.setModal(true)}>Attend</button>
+          </span>
+        </div>
+      </div>
+  )
+}
+export default BottonBar;

--- a/components/Event/Modal.js
+++ b/components/Event/Modal.js
@@ -1,0 +1,51 @@
+import { useState} from 'react';
+
+function Modal(props){
+
+
+  const [counter, setCounter] = useState(0);
+
+  //increase counter
+  const increase = () => {
+    setCounter(counter => counter + 1);
+  };
+
+  //decrease counter
+  const decrease = () => {
+    if(counter > 0){
+      setCounter(counter => counter - 1);
+    }
+  };
+
+  return (
+      <div className={"relative z-10 " + (props.modal ? "" : "hidden")} aria-labelledby="modal-title" role="dialog" aria-modal="true">
+        <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"></div>
+        <div className="fixed inset-0 z-10 overflow-y-auto">
+          <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+            <div className="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
+              <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                <div className="float-right cursor-pointer" onClick={() => props.setModal(false)}>X</div>
+                <h1 className="font-bold">Complete your RSVP</h1>
+                <div>Are you bringing anyone?</div>
+                <div className="flex flex-row justify-between border-[1px] border-black max-w-full h-24 px-5 items-center">
+                  <span>{counter}</span>
+                  <div className='flex flex-row gap-5'>
+                    <button onClick={decrease}>-</button>
+                    <button onClick={increase}>+</button>
+                  </div>
+                </div>
+                <div className="max-w-full mt-4">
+                  <button type="button" className="w-full py-2 border-[1px] border-blue-400 text-blue-400 rounded-lg" onClick={() => saveAttendee(props.userId, props.parentObjectId)}>Submit</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+  );
+
+
+}
+
+
+export default Modal;

--- a/pages/event/index.js
+++ b/pages/event/index.js
@@ -21,9 +21,20 @@ function Event() {
 
   const [eventData, setEventData] = useState();
   const [hostsData, setHostsData] = useState();
+  const [counter, setCounter] = useState(0);
 
   // const parentObjectId = '64091cf1ee0ae9fed40f14ba';
   const parentObjectId = '6423680881ba99669b08fa7d';
+
+  //increase counter
+  const increase = () => {
+    setCounter(count => count + 1);
+  };
+
+  //decrease counter
+  const decrease = () => {
+    setCounter(count => count - 1);
+  };
 
   useEffect(() => {
     retrieveEvent(parentObjectId).then(
@@ -147,9 +158,36 @@ function Event() {
             <button type="button" className="px-5 py-3 bg-red-500 rounded-lg font-bold text-white">Attend</button>
           </span>
         </div>
-
-
       </div>
+
+      <div class="relative z-10" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+
+        <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"></div>
+
+        <div class="fixed inset-0 z-10 overflow-y-auto">
+          <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+
+            <div class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
+              <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                <h1 className="font-bold">Complete your RSVP</h1>
+                <div>Are you bringing anyone?</div>
+                <div className="flex flex-row justify-between border-[1px] border-black max-w-full h-24 px-5 items-center">
+                  <span>{counter}</span>
+                  <div className='flex flex-row gap-5'>
+                    <button onClick={decrease}>-</button>
+                    <button onClick={increase}>+</button>
+                  </div>
+                </div>
+                <div className="max-w-full mt-4">
+                  <button type="button" className="w-full py-2 border-[1px] border-blue-400 text-blue-400 rounded-lg">Submit</button>
+                </div>
+              </div>
+
+            </div>
+          </div>
+        </div>
+      </div>
+
     </div>
   );
 }

--- a/pages/event/index.js
+++ b/pages/event/index.js
@@ -1,6 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import Comment from '../../components/Comment/Comment';
 import Image from 'next/image';
+import Modal from '../../components/Event/Modal';
+
+
 
 async function retrieveEvent(parentObjectId) {
   const response = await fetch('http://34.210.145.64:8000/events/retrieve-event/' + parentObjectId);
@@ -40,21 +43,12 @@ function Event() {
 
   const [eventData, setEventData] = useState();
   const [hostsData, setHostsData] = useState();
-  const [counter, setCounter] = useState(0);
   const [modal, setModal] = useState(false);
+
 
   const parentObjectId = '6423680881ba99669b08fa7d';
   const userId = "64221158e1bbeb5fc205ed21"
 
-  //increase counter
-  const increase = () => {
-    setCounter(count => count + 1);
-  };
-
-  //decrease counter
-  const decrease = () => {
-    setCounter(count => count - 1);
-  };
 
   useEffect(() => {
     retrieveEvent(parentObjectId).then(
@@ -180,32 +174,7 @@ function Event() {
           </span>
         </div>
       </div>
-
-      {/* Modal */}
-      <div className={"relative z-10 " + (modal ? "" : "hidden")} aria-labelledby="modal-title" role="dialog" aria-modal="true">
-        <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"></div>
-        <div className="fixed inset-0 z-10 overflow-y-auto">
-          <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
-            <div className="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
-              <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-                <div className="float-right cursor-pointer" onClick={() => setModal(false)}>X</div>
-                <h1 className="font-bold">Complete your RSVP</h1>
-                <div>Are you bringing anyone?</div>
-                <div className="flex flex-row justify-between border-[1px] border-black max-w-full h-24 px-5 items-center">
-                  <span>{counter}</span>
-                  <div className='flex flex-row gap-5'>
-                    <button onClick={decrease}>-</button>
-                    <button onClick={increase}>+</button>
-                  </div>
-                </div>
-                <div className="max-w-full mt-4">
-                  <button type="button" className="w-full py-2 border-[1px] border-blue-400 text-blue-400 rounded-lg" onClick={() => saveAttendee(userId, parentObjectId)}>Submit</button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+      <Modal modal={modal} setModal={setModal} saveAttendee={saveAttendee} userId={userId} parentObjectId={parentObjectId} />
     </div>
   );
 }

--- a/pages/event/index.js
+++ b/pages/event/index.js
@@ -126,7 +126,29 @@ function Event() {
           </div>
         </div>
       </div>
-      <div class="fixed bottom-0 left-0 z-50 w-full h-16 bg-white border-t border-gray-200 dark:bg-gray-700 dark:border-gray-600">
+      <div class="fixed bottom-0 left-0 z-50 w-full h-20 bg-white flex flex-row justify-between">
+        <div className="flex flex-col">
+          <span>WED, APR 26 - 6:00 PDT</span>
+          <span className="font-bold">{title}</span>
+        </div>
+        <div className="flex flex-row gap-2">
+          <span>Free</span>
+          <span>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0111.186 0z" />
+            </svg>
+          </span>
+          <span>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 8.25H7.5a2.25 2.25 0 00-2.25 2.25v9a2.25 2.25 0 002.25 2.25h9a2.25 2.25 0 002.25-2.25v-9a2.25 2.25 0 00-2.25-2.25H15m0-3l-3-3m0 0l-3 3m3-3V15" />
+            </svg>
+          </span>
+          <span>
+            <button type="button" className="">Attend</button>
+          </span>
+        </div>
+
+
       </div>
     </div>
   );

--- a/pages/event/index.js
+++ b/pages/event/index.js
@@ -144,7 +144,7 @@ function Event() {
             </svg>
           </span>
           <span>
-            <button type="button" className="px-5 py-3 bg-red-500 rounded-lg">Attend</button>
+            <button type="button" className="px-5 py-3 bg-red-500 rounded-lg font-bold text-white">Attend</button>
           </span>
         </div>
 

--- a/pages/event/index.js
+++ b/pages/event/index.js
@@ -127,24 +127,24 @@ function Event() {
         </div>
       </div>
       <div class="fixed bottom-0 left-0 z-50 w-full h-20 bg-white flex flex-row justify-between">
-        <div className="flex flex-col">
+        <div className="flex flex-col self-center">
           <span>WED, APR 26 - 6:00 PDT</span>
           <span className="font-bold">{title}</span>
         </div>
-        <div className="flex flex-row gap-2">
+        <div className="flex flex-row gap-2 self-center items-center">
           <span>Free</span>
           <span>
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
               <path strokeLinecap="round" strokeLinejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0111.186 0z" />
             </svg>
           </span>
-          <span>
+          <span className="p-3 border-[1px] border-blue rounded-lg">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
               <path strokeLinecap="round" strokeLinejoin="round" d="M9 8.25H7.5a2.25 2.25 0 00-2.25 2.25v9a2.25 2.25 0 002.25 2.25h9a2.25 2.25 0 002.25-2.25v-9a2.25 2.25 0 00-2.25-2.25H15m0-3l-3-3m0 0l-3 3m3-3V15" />
             </svg>
           </span>
           <span>
-            <button type="button" className="">Attend</button>
+            <button type="button" className="px-5 py-3 bg-red-500 rounded-lg">Attend</button>
           </span>
         </div>
 

--- a/pages/event/index.js
+++ b/pages/event/index.js
@@ -4,13 +4,11 @@ import Image from 'next/image';
 
 async function retrieveEvent(parentObjectId) {
   const response = await fetch('http://34.210.145.64:8000/events/retrieve-event/' + parentObjectId);
-  return response; // Note: Can I make this response.json()?
+  return response;
 }
-// Make into put function
+
 async function saveAttendee(userId, parentObjectId) {
-
   const url = 'http://34.210.145.64:8000/events/save-attendee';
-
   const data = { "userId": userId, "eventId": parentObjectId };
 
   const response = await fetch(
@@ -27,11 +25,12 @@ async function saveAttendee(userId, parentObjectId) {
   return response;
 
 }
+
 function Event() {
 
   let title = 'Some Event';
   let host = "Ryan";
-  let hostPhoto = "/src/img/host.png"; // TODO: CHA
+  let hostPhoto = "/src/img/host.png";
   let photo = "./someline";
   let location = "someaddress";
   let detailsParagraph = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut vitae erat eleifend, egestas lorem eu, vehicula nisl. Cras bibendum tellus eu purus accumsan, quis aliquet ipsum cursus. Sed nec iaculis urna, ut lobortis lacus. Vestibulum at sem bibendum, porta dolor vel, fermentum tortor. Nulla non aliquam arcu. Integer eget aliquet risus. Nullam non malesuada felis. Sed commodo hendrerit erat, et placerat felis vulputate vel. Suspendisse non porta lectus. Cras in neque gravida, lacinia ex ut, tempus est. Curabitur quis massa non ante porta lacinia. Nunc nec urna ex. Maecenas lorem nunc, finibus sit amet tincidunt sit amet, fringilla euismod dolor. Quisque risus diam, consequat eu posuere maximus, finibus ac nulla. Donec feugiat ante id est elementum, a maximus purus sodales. Nullam efficitur odio vel nisl tincidunt tristique. Maecenas vestibulum bibendum arcu, at rutrum sem hendrerit ut. In a facilisis lacus. Donec vitae venenatis enim, sed commodo nibh. Aenean at blandit est. In id faucibus elit. Phasellus lobortis, nunc nec auctor accumsan, orci odio tempor nibh, ac iaculis urna justo sit amet tellus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere ipsum sit amet ultrices gravida.';
@@ -158,6 +157,7 @@ function Event() {
           </div>
         </div>
       </div>
+      {/* Bottom Bar */}
       <div class="fixed bottom-0 left-0 z-50 w-full h-20 bg-white flex flex-row justify-between">
         <div className="flex flex-col self-center">
           <span>WED, APR 26 - 6:00 PDT</span>
@@ -184,10 +184,8 @@ function Event() {
       {/* Modal */}
       <div className={"relative z-10 " + (modal ? "" : "hidden")} aria-labelledby="modal-title" role="dialog" aria-modal="true">
         <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"></div>
-
         <div className="fixed inset-0 z-10 overflow-y-auto">
           <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
-
             <div className="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
               <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
                 <div className="float-right cursor-pointer" onClick={() => setModal(false)}>X</div>
@@ -201,16 +199,13 @@ function Event() {
                   </div>
                 </div>
                 <div className="max-w-full mt-4">
-                  {/* Make submit attendee here */}
                   <button type="button" className="w-full py-2 border-[1px] border-blue-400 text-blue-400 rounded-lg" onClick={() => saveAttendee(userId, parentObjectId)}>Submit</button>
                 </div>
               </div>
-
             </div>
           </div>
         </div>
       </div>
-
     </div>
   );
 }

--- a/pages/event/index.js
+++ b/pages/event/index.js
@@ -126,6 +126,8 @@ function Event() {
           </div>
         </div>
       </div>
+      <div class="fixed bottom-0 left-0 z-50 w-full h-16 bg-white border-t border-gray-200 dark:bg-gray-700 dark:border-gray-600">
+      </div>
     </div>
   );
 }

--- a/pages/event/index.js
+++ b/pages/event/index.js
@@ -6,7 +6,27 @@ async function retrieveEvent(parentObjectId) {
   const response = await fetch('http://34.210.145.64:8000/events/retrieve-event/' + parentObjectId);
   return response; // Note: Can I make this response.json()?
 }
+// Make into put function
+async function saveAttendee(userId, parentObjectId) {
 
+  const url = 'http://34.210.145.64:8000/events/save-attendee';
+
+  const data = { "userId": userId, "eventId": parentObjectId };
+
+  const response = await fetch(
+    url, {
+    method: "POST",
+    mode: "no-cors",
+    headers: {
+      "Content-type": "application/json",
+    },
+    body: JSON.stringify(data),
+    Cache: 'default',
+  });
+
+  return response;
+
+}
 function Event() {
 
   let title = 'Some Event';
@@ -22,9 +42,10 @@ function Event() {
   const [eventData, setEventData] = useState();
   const [hostsData, setHostsData] = useState();
   const [counter, setCounter] = useState(0);
+  const [modal, setModal] = useState(false);
 
-  // const parentObjectId = '64091cf1ee0ae9fed40f14ba';
   const parentObjectId = '6423680881ba99669b08fa7d';
+  const userId = "64221158e1bbeb5fc205ed21"
 
   //increase counter
   const increase = () => {
@@ -155,20 +176,21 @@ function Event() {
             </svg>
           </span>
           <span>
-            <button type="button" className="px-5 py-3 bg-red-500 rounded-lg font-bold text-white">Attend</button>
+            <button type="button" className="px-5 py-3 bg-red-500 rounded-lg font-bold text-white" onClick={() => setModal(true)}>Attend</button>
           </span>
         </div>
       </div>
 
-      <div class="relative z-10" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+      {/* Modal */}
+      <div className={"relative z-10 " + (modal ? "" : "hidden")} aria-labelledby="modal-title" role="dialog" aria-modal="true">
+        <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"></div>
 
-        <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"></div>
+        <div className="fixed inset-0 z-10 overflow-y-auto">
+          <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
 
-        <div class="fixed inset-0 z-10 overflow-y-auto">
-          <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
-
-            <div class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
-              <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+            <div className="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
+              <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                <div className="float-right cursor-pointer" onClick={() => setModal(false)}>X</div>
                 <h1 className="font-bold">Complete your RSVP</h1>
                 <div>Are you bringing anyone?</div>
                 <div className="flex flex-row justify-between border-[1px] border-black max-w-full h-24 px-5 items-center">
@@ -179,7 +201,8 @@ function Event() {
                   </div>
                 </div>
                 <div className="max-w-full mt-4">
-                  <button type="button" className="w-full py-2 border-[1px] border-blue-400 text-blue-400 rounded-lg">Submit</button>
+                  {/* Make submit attendee here */}
+                  <button type="button" className="w-full py-2 border-[1px] border-blue-400 text-blue-400 rounded-lg" onClick={() => saveAttendee(userId, parentObjectId)}>Submit</button>
                 </div>
               </div>
 

--- a/pages/event/index.js
+++ b/pages/event/index.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import Comment from '../../components/Comment/Comment';
 import Image from 'next/image';
 import Modal from '../../components/Event/Modal';
+import BottonBar from '../../components/Event/Bottom-Bar';
 
 
 
@@ -151,29 +152,7 @@ function Event() {
           </div>
         </div>
       </div>
-      {/* Bottom Bar */}
-      <div class="fixed bottom-0 left-0 z-50 w-full h-20 bg-white flex flex-row justify-between">
-        <div className="flex flex-col self-center">
-          <span>WED, APR 26 - 6:00 PDT</span>
-          <span className="font-bold">{title}</span>
-        </div>
-        <div className="flex flex-row gap-2 self-center items-center">
-          <span>Free</span>
-          <span>
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0111.186 0z" />
-            </svg>
-          </span>
-          <span className="p-3 border-[1px] border-blue rounded-lg">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M9 8.25H7.5a2.25 2.25 0 00-2.25 2.25v9a2.25 2.25 0 002.25 2.25h9a2.25 2.25 0 002.25-2.25v-9a2.25 2.25 0 00-2.25-2.25H15m0-3l-3-3m0 0l-3 3m3-3V15" />
-            </svg>
-          </span>
-          <span>
-            <button type="button" className="px-5 py-3 bg-red-500 rounded-lg font-bold text-white" onClick={() => setModal(true)}>Attend</button>
-          </span>
-        </div>
-      </div>
+      <BottonBar title={title} setModal={setModal} />
       <Modal modal={modal} setModal={setModal} saveAttendee={saveAttendee} userId={userId} parentObjectId={parentObjectId} />
     </div>
   );

--- a/pages/event/index.js
+++ b/pages/event/index.js
@@ -23,7 +23,7 @@ function Event() {
   const [hostsData, setHostsData] = useState();
 
   // const parentObjectId = '64091cf1ee0ae9fed40f14ba';
-  const parentObjectId = '6418fc1bfa9f8c7a6804cf78';
+  const parentObjectId = '6423680881ba99669b08fa7d';
 
   useEffect(() => {
     retrieveEvent(parentObjectId).then(


### PR DESCRIPTION
# Description
- Bottom show attend button, event datetime, and event name 
- Modal with counter that sends `userId` to `save-attendee` `PUT`

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
 
# Screen shots
Bottom Bar: 
<img width="955" alt="Screenshot 2023-03-28 at 5 15 30 PM" src="https://user-images.githubusercontent.com/11698908/228394635-24b0be37-4644-4ec9-a22d-bd19f343987f.png">
Modal: 
<img width="955" alt="Screenshot 2023-03-28 at 5 15 55 PM" src="https://user-images.githubusercontent.com/11698908/228394678-c5e05c2b-6633-4b28-b040-2b07dc3b7b75.png">

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: Bottom Bar
  - [x] Does `Attend` button display modal?
  - [x] Does Modal display event name?
- [x] Test B: Modal
  - [x] Does counter increment?
  - [x] Does Submit send `userId` to `save-attendee`?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
