### PR TITLE
Group home page

### DIFF
--- a/components/Group/My-Groups.js
+++ b/components/Group/My-Groups.js
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import Link from 'next/link'
+
+async function retrieveGroups() {
+  const response = await fetch('http://35.86.78.63:8000/group/retrieve-groups');
+  return response; // Note: Can I make this response.json()?
+}
+
+export default function MyGroups() {
+  const [groups, setGroups] = useState();
+
+  useEffect(() => {
+    retrieveGroups().then(
+      result => result.json()).then(
+        data => {
+          setGroups(data.groups);
+        }
+      );
+  }, []);
+
+  return (
+    <div className="flex flex-row justify-center gap-5 pt-5">
+      {groups?.map((group) => (
+        <Link href={"/group/" + `${group.id}`}>
+          <div className="flex flex-row bg-white gap-5 p-3 rounded-lg">
+            <Image
+              src={group.picture}
+              alt="group photo"
+              width={150}
+              height={150}
+            />
+            <div className="flex flex-col">
+              <span>
+                {group.name}
+              </span>
+              <span>
+                {group.location}
+              </span>
+            </div>
+          </div>
+        </Link>
+      ))}
+    </div>
+  )
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,7 +5,7 @@ export default function App({ Component, pageProps }) {
   return (
     <>
       <TopBar />
-      <Component {...pageProps} />;
+      <Component {...pageProps} />
     </>
 
   );

--- a/pages/group/[pid].js
+++ b/pages/group/[pid].js
@@ -4,6 +4,7 @@ import 'react-tabs/style/react-tabs.css';
 import React, { useState, useEffect } from 'react';
 import Members from '../../components/Members/Members';
 import Events from "../../components/Group/Events";
+import { useRouter } from "next/router";
 
 
 async function retrieveGroup(parentObjectId) {
@@ -13,19 +14,22 @@ async function retrieveGroup(parentObjectId) {
 
 function Group() {
 
+  const router = useRouter();
+  const { pid } = router.query;
+
   // const groupID = '6414a97c4e69425c9105db21'; //OC happy hour
   const groupID = '6425c4e287ce053cff07f502'; // OC Python
 
   const [group, setGroup] = useState();
 
   useEffect(() => {
-    retrieveGroup(groupID).then(
+    retrieveGroup(pid).then(
       result => result.json()).then(
         data => {
           setGroup(data);
         }
       );
-  }, []);
+  }, [pid]);
 
 
   return (

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,52 +1,12 @@
 // create component for groups and import here
-import { useEffect, useState } from "react";
-import Image from "next/image";
-import Link from 'next/link'
-
-async function retrieveGroups() {
-  const response = await fetch('http://35.86.78.63:8000/group/retrieve-groups');
-  return response; // Note: Can I make this response.json()?
-}
-
+import MyGroups from "../components/Group/My-Groups";
 
 function HomePage() {
 
-
-  const [groups, setGroups] = useState();
-
-  useEffect(() => {
-    retrieveGroups().then(
-      result => result.json()).then(
-        data => {
-          console.log(data.groups[0].id);
-          setGroups(data.groups);
-        }
-      );
-  }, []);
-
   return (
-    <div className="flex flex-row justify-center gap-5">
-      {groups?.map((group) => (
-        <Link href={"/group/" + `${group.id}`}>
-          <div className="flex flex-row bg-white gap-5 p-3 rounded-lg">
-            <Image
-              src={group.picture}
-              alt="group photo"
-              width={150}
-              height={150}
-            />
-            <div className="flex flex-col">
-              <span>
-                {group.name}
-              </span>
-              <span>
-                {group.location}
-              </span>
-            </div>
-          </div>
-        </Link>
-      ))}
-    </div>
+    <>
+      <MyGroups />
+    </>
   );
 }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,53 @@
+// create component for groups and import here
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import Link from 'next/link'
+
+async function retrieveGroups() {
+  const response = await fetch('http://35.86.78.63:8000/group/retrieve-groups');
+  return response; // Note: Can I make this response.json()?
+}
+
+
 function HomePage() {
-  return <div>Welcome to Next.js!</div>
+
+
+  const [groups, setGroups] = useState();
+
+  useEffect(() => {
+    retrieveGroups().then(
+      result => result.json()).then(
+        data => {
+          console.log(data.groups[0].id);
+          setGroups(data.groups);
+        }
+      );
+  }, []);
+
+  return (
+    <div className="flex flex-row justify-center gap-5">
+      {groups?.map((group) => (
+        <Link href={"/group/" + `${group.id}`}>
+          <div className="flex flex-row bg-white gap-5 p-3 rounded-lg">
+            <Image
+              src={group.picture}
+              alt="group photo"
+              width={150}
+              height={150}
+            />
+            <div className="flex flex-col">
+              <span>
+                {group.name}
+              </span>
+              <span>
+                {group.location}
+              </span>
+            </div>
+          </div>
+        </Link>
+      ))}
+    </div>
+  );
 }
 
 export default HomePage


### PR DESCRIPTION
# Description
Displays all groups in `<MyGroup/>`
- Calls `/group/retrieve-groups`
- Displays in `<MyGroup/>`
- Clicking link goes to `/group/GROUPID` 
- Page gets `GROUPID` from url and calls `/group/retrieve-group/GROUPID` 

 
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# Screen shots
<img width="938" alt="Screenshot 2023-04-06 at 4 27 06 PM" src="https://user-images.githubusercontent.com/11698908/230511604-ca4597a8-e8ce-4d10-9a4f-d9ce60decadc.png">

**NOTE: No graphic changes were made to groups page**

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: Does `group/GROUID` pull up group?
- [x] Test B: Does group list render?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
