### PR TITLE
Upcoming events

### DIFF
--- a/components/Group/Events.js
+++ b/components/Group/Events.js
@@ -13,6 +13,7 @@ function Events(props) {
   const [displayEvents, setDisplayEvents] = useState([]);
   const [highlightArea, setHighlightArea] = useState();
 
+  // Function sets display events and highlights "Upcoming" or "Past" events
   const changeDisplayEvents = (weekState, highlightAreaParam, allEvents) => {
     setHighlightArea(highlightAreaParam);
     setDisplayEvents([]);
@@ -21,7 +22,6 @@ function Events(props) {
       setDisplayEvents(displayEvents => [...displayEvents, ...allEvents.filter((event) => event.week === state)]);
     })
   }
-  // TODO: make comments on code
 
   useEffect(() => {
     retrieveEvents(props.groupName).then(

--- a/components/Group/Events.js
+++ b/components/Group/Events.js
@@ -27,7 +27,6 @@ function Events(props) {
     retrieveEvents(props.groupName).then(
       result => result.json()).then(
         data => {
-          // console.log(data.events);
           setEvents(data.events);
           changeDisplayEvents(['this', 'next'], 'upcoming', data.events);
         }

--- a/components/Group/Events.js
+++ b/components/Group/Events.js
@@ -37,10 +37,10 @@ function Events(props) {
   return (
     <div className="flex flex-row w-[1000px] gap-10">
       <div className="flex flex-col w-1/4 p-5 bg-white rounded-lg gap-2 text-lg">
-        <span className={highlightArea === 'upcoming' ? "border-r-2 border-r-blue-600 cursor-pointer" : ""} onClick={() => changeDisplayEvents(['this', 'next'], 'upcoming', events)}>
+        <span className={"cursor-pointer" + (highlightArea === 'upcoming' ? " border-r-2 border-r-blue-600" : "")} onClick={() => changeDisplayEvents(['this', 'next'], 'upcoming', events)}>
           Upcoming
         </span>
-        <span className={highlightArea === 'past' ? "border-r-2 border-r-blue-600 cursor-pointer" : ""} onClick={() => changeDisplayEvents(['last'], 'past', events)}>
+        <span className={"cursor-pointer " + (highlightArea === 'past' ? "border-r-2 border-r-blue-600" : "")} onClick={() => changeDisplayEvents(['last'], 'past', events)}>
           Past
         </span>
         <span>

--- a/components/Group/Events.js
+++ b/components/Group/Events.js
@@ -36,7 +36,7 @@ function Events(props) {
   return (
     <div className="flex flex-row w-[1000px] gap-10">
       <div className="flex flex-col w-1/4 p-5 bg-white rounded-lg gap-2 text-lg">
-        <span className={"cursor-pointer" + (highlightArea === 'upcoming' ? " border-r-2 border-r-blue-600" : "")} onClick={() => changeDisplayEvents(['this', 'next'], 'upcoming', events)}>
+        <span className={"cursor-pointer " + (highlightArea === 'upcoming' ? "border-r-2 border-r-blue-600" : "")} onClick={() => changeDisplayEvents(['this', 'next'], 'upcoming', events)}>
           Upcoming
         </span>
         <span className={"cursor-pointer " + (highlightArea === 'past' ? "border-r-2 border-r-blue-600" : "")} onClick={() => changeDisplayEvents(['last'], 'past', events)}>

--- a/components/Group/Events.js
+++ b/components/Group/Events.js
@@ -10,12 +10,26 @@ async function retrieveEvents(groupName) {
 
 function Events(props) {
   const [events, setEvents] = useState();
+  const [displayEvents, setDisplayEvents] = useState([]);
+  const [highlightArea, setHighlightArea] = useState();
+
+  const changeDisplayEvents = (weekState, highlightAreaParam, allEvents) => {
+    setHighlightArea(highlightAreaParam);
+    setDisplayEvents([]);
+
+    weekState.map((state) => {
+      setDisplayEvents(displayEvents => [...displayEvents, ...allEvents.filter((event) => event.week === state)]);
+    })
+  }
+  // TODO: make comments on code
 
   useEffect(() => {
     retrieveEvents(props.groupName).then(
       result => result.json()).then(
         data => {
+          // console.log(data.events);
           setEvents(data.events);
+          changeDisplayEvents(['this', 'next'], 'upcoming', data.events);
         }
       );
   }, []);
@@ -23,10 +37,10 @@ function Events(props) {
   return (
     <div className="flex flex-row w-[1000px] gap-10">
       <div className="flex flex-col w-1/4 p-5 bg-white rounded-lg gap-2 text-lg">
-        <span className="border-r-2 border-r-blue-600">
+        <span className={highlightArea === 'upcoming' ? "border-r-2 border-r-blue-600 cursor-pointer" : ""} onClick={() => changeDisplayEvents(['this', 'next'], 'upcoming', events)}>
           Upcoming
         </span>
-        <span>
+        <span className={highlightArea === 'past' ? "border-r-2 border-r-blue-600 cursor-pointer" : ""} onClick={() => changeDisplayEvents(['last'], 'past', events)}>
           Past
         </span>
         <span>
@@ -34,7 +48,7 @@ function Events(props) {
         </span>
       </div>
       <div className="flex flex-col gap-5 w-1/2">
-        {events?.map((event, index) => (
+        {displayEvents?.map((event, index) => (
           <Link href={"/event/" + `${event._id.$oid}`}>
             <div className="flex flex-col  bg-white w-full rounded-lg p-2" key={index}>
               <div className="flex flex-row justify-between">
@@ -66,9 +80,6 @@ function Events(props) {
                     className="rounded-lg"
                   />
                 </div>
-              </div>
-              <div className="text-sm">
-                {event?.details_paragraph}
               </div>
               <div className="flex flex-row justify-between w-max-full text-sm">
                 <span className='self-end'>

--- a/pages/group/[pid].js
+++ b/pages/group/[pid].js
@@ -58,7 +58,6 @@ function Group() {
             </TabPanel>
             <TabPanel>
               <Events groupName={group?.group.name} />
-              {/* Put group name here */}
             </TabPanel>
             <TabPanel>
               <Members groupName={group?.group.name} />

--- a/pages/group/[pid].js
+++ b/pages/group/[pid].js
@@ -57,7 +57,7 @@ function Group() {
               </div>
             </TabPanel>
             <TabPanel>
-              <Events groupName={'OC Python'} />
+              <Events groupName={group?.group.name} />
               {/* Put group name here */}
             </TabPanel>
             <TabPanel>


### PR DESCRIPTION
# Description
Displays `Past` `events` or `Upcoming` and current `events` with `onClick`
- Clicking on `Upcoming` or `Past` will set `displayEvents` and `highlightArea` 
- `changeDisplayEvents` take params `weekState`, `highlightAreaParam`, and `allEvents` to set `highlightArea` and `displayEvents` which are feed .map() to display `events`
- ternaries next to `Upcoming` and `Past` display blue right border 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Screen shots
**Upcoming events**
<img width="994" alt="Screenshot 2023-04-11 at 4 52 44 PM" src="https://user-images.githubusercontent.com/11698908/231312770-c8eb706b-9b98-4796-b73c-14cc34651135.png">
**Past events**
<img width="994" alt="Screenshot 2023-04-11 at 4 53 18 PM" src="https://user-images.githubusercontent.com/11698908/231312816-df2b1a5b-5e6a-4a77-b7f3-ba1451cca41d.png">

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
